### PR TITLE
style: Move modals so the keyboard doesn't overlap.

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -8,6 +8,7 @@ import {
   StyleSheet,
   TouchableWithoutFeedback,
   BackHandler,
+  Platform,
 } from 'react-native';
 import { polyfill } from 'react-lifecycles-compat';
 import ThemedPortal from './Portal/ThemedPortal';
@@ -165,9 +166,14 @@ polyfill(Modal);
 
 export default Modal;
 
+const marginTop = Platform.select({
+  ios: { marginTop: '25%' },
+  android: { marginTop: '-5%' },
+});
+
 const styles = StyleSheet.create({
   wrapper: {
     ...StyleSheet.absoluteFillObject,
-    justifyContent: 'center',
+    ...marginTop,
   },
 });


### PR DESCRIPTION
This will make dialogs render near the top, out of the way of the keyboard. On iOS, for some reason the dialog still renders beneath the title bar at the top. Not perfect, but, as a quick patch it seems to work. Still need coverage across different screen sizes to verify.